### PR TITLE
Remove reference to abandonware (uBlock)

### DIFF
--- a/content/pages/01_main.rst
+++ b/content/pages/01_main.rst
@@ -4,7 +4,7 @@
 
 The EasyList filter lists are sets of rules originally designed for `Adblock <http://adblock.mozdev.org/>`__ that automatically remove unwanted content from the internet, including annoying adverts, bothersome banners and troublesome tracking. The filter lists are currently maintained by four authors, Fanboy, MonztA, Famlam and Khrin, who are ably assisted by an ample forum community.
 
-The links listed below allow you to select filter lists for use in your browser provided that you are using a compatible ad blocker (tested with `Adblock Plus <https://adblockplus.org/>`_, `AdBlock <https://getadblock.com/>`_, `uBlock Origin <https://github.com/gorhill/uBlock/>`_ and `uBlock <https://www.ublock.org/>`_). Furthermore, EasyPrivacy Tracking Protection List is available for `Internet Explorer 9 <http://windows.microsoft.com/en-us/internet-explorer/download-ie>`_ and higher.
+The links listed below allow you to select filter lists for use in your browser provided that you are using a compatible ad blocker (tested with `Adblock Plus <https://adblockplus.org/>`_, `AdBlock <https://getadblock.com/>`_ and `uBlock Origin <https://github.com/gorhill/uBlock/>`_). Furthermore, EasyPrivacy Tracking Protection List is available for `Internet Explorer 9 <http://windows.microsoft.com/en-us/internet-explorer/download-ie>`_ and higher.
 
 --------
 EasyList


### PR DESCRIPTION
I think it is a disservice to users to keep referring to uBlock as if it is a valid option: it is essentially abandonware. The issues reported by people are piling up with no answer from the developer, and no substantial work has been done on it for more than two years now. Given all the fixes that gone into uBO itself, it's more than likely that plain uBlock suffers from a lot of defects.